### PR TITLE
fix width and height usage for icon group, especially when loading from an icon file (#4)

### DIFF
--- a/src/main/data/IconFile.ts
+++ b/src/main/data/IconFile.ts
@@ -148,7 +148,7 @@ export default class IconFile {
 				const bitCount = readUint8WithLastOffset(view, offset + 6, totalSize);
 				let data: IconItem | RawIconItem;
 				if (view.getUint32(dataOffset, true) === 0x28) {
-					data = IconItem.from(bin, dataOffset, dataSize);
+					data = IconItem.from(width, height, bin, dataOffset, dataSize);
 				} else {
 					data = RawIconItem.from(
 						bin.slice(dataOffset, dataOffset + dataSize),

--- a/src/main/resource/IconGroupEntry.ts
+++ b/src/main/resource/IconGroupEntry.ts
@@ -193,11 +193,38 @@ export default class IconGroupEntry {
 		let entry: ResourceEntry | undefined =
 			destEntries.filter((e) => (e.type === 14 && e.id === iconGroupID && e.lang === lang))[0];
 		let binEntry: ArrayBuffer;
-		const tmpIconArray = icons.map((icon) => {
+		interface TempIconData {
+			base: IconItem | RawIconItem;
+			bm: {
+				width: number;
+				height: number;
+				planes: number;
+				bitCount: number;
+			};
+			bin: ArrayBuffer;
+			id: number;
+		}
+		const tmpIconArray: TempIconData[] = icons.map((icon): TempIconData => {
 			if (icon.isIcon()) {
+				let { width, height } = icon;
+				if (width === null) {
+					width = icon.bitmapInfo.width;
+				}
+				if (height === null) {
+					height = icon.bitmapInfo.height;
+					// if mask is specified, the icon height must be the half of bitmap height
+					if (icon.masks !== null) {
+						height = Math.floor(height / 2);
+					}
+				}
 				return {
 					base: icon,
-					bm: icon.bitmapInfo,
+					bm: {
+						width: width,
+						height: height,
+						planes: icon.bitmapInfo.planes,
+						bitCount: icon.bitmapInfo.bitCount
+					},
 					bin: icon.generate(),
 					id: 0
 				};

--- a/src/test/basic/IconFile.ts
+++ b/src/test/basic/IconFile.ts
@@ -20,18 +20,17 @@ describe('IconFile', () => {
 		expect(icon.icons.length).toEqual(2);
 
 		const iconsSorted = icon.icons.sort((a, b) => (getIconWidth(a) - getIconWidth(b)));
-		expect(iconsSorted[0].width).toEqual(16);
-		expect(iconsSorted[0].height).toEqual(16);
-		expect(iconsSorted[0].bitCount).toEqual(4);
-		expect(iconsSorted[0].data.isIcon()).toBeTruthy();
-		expect(iconsSorted[0].data.isIcon() && iconsSorted[0].data.pixels.byteLength).toBeGreaterThan(0);
-		expect(iconsSorted[0].data.isIcon() && iconsSorted[0].data.masks).toBeTruthy();
-		expect(iconsSorted[1].width).toEqual(32);
-		expect(iconsSorted[1].height).toEqual(32);
-		expect(iconsSorted[1].bitCount).toEqual(4);
-		expect(iconsSorted[1].data.isIcon()).toBeTruthy();
-		expect(iconsSorted[1].data.isIcon() && iconsSorted[1].data.pixels.byteLength).toBeGreaterThan(0);
-		expect(iconsSorted[1].data.isIcon() && iconsSorted[1].data.masks).toBeTruthy();
+		[[16, 16], [32, 32]].forEach(([width, height], i) => {
+			const icon = iconsSorted[i];
+			expect(icon.width).toEqual(width);
+			expect(icon.height).toEqual(height);
+			expect(icon.bitCount).toEqual(4);
+			expect(icon.data.isIcon()).toBeTruthy();
+			expect(icon.data.isIcon() && icon.data.pixels.byteLength).toBeGreaterThan(0);
+			expect(icon.data.isIcon() && icon.data.masks).toBeTruthy();
+			expect(icon.data.isIcon() && icon.data.width).toEqual(width);
+			expect(icon.data.isIcon() && icon.data.height).toEqual(height);
+		});
 	});
 	it('should be parsed correctly 2', () => {
 		const bin = loadIcon('data1_4b16_4b32_4b64_png256');
@@ -40,27 +39,22 @@ describe('IconFile', () => {
 		expect(icon.icons.length).toEqual(4);
 
 		const iconsSorted = icon.icons.sort((a, b) => (getIconWidth(a) - getIconWidth(b)));
-		expect(iconsSorted[0].width).toEqual(16);
-		expect(iconsSorted[0].height).toEqual(16);
-		expect(iconsSorted[0].bitCount).toEqual(4);
-		expect(iconsSorted[0].data.isIcon()).toBeTruthy();
-		expect(iconsSorted[0].data.isIcon() && iconsSorted[0].data.pixels.byteLength).toBeGreaterThan(0);
-		expect(iconsSorted[0].data.isIcon() && iconsSorted[0].data.masks).toBeTruthy();
-		expect(iconsSorted[1].width).toEqual(32);
-		expect(iconsSorted[1].height).toEqual(32);
-		expect(iconsSorted[1].bitCount).toEqual(4);
-		expect(iconsSorted[1].data.isIcon()).toBeTruthy();
-		expect(iconsSorted[1].data.isIcon() && iconsSorted[1].data.pixels.byteLength).toBeGreaterThan(0);
-		expect(iconsSorted[1].data.isIcon() && iconsSorted[1].data.masks).toBeTruthy();
-		expect(iconsSorted[2].width).toEqual(64);
-		expect(iconsSorted[2].height).toEqual(64);
-		expect(iconsSorted[2].bitCount).toEqual(4);
-		expect(iconsSorted[2].data.isIcon()).toBeTruthy();
-		expect(iconsSorted[2].data.isIcon() && iconsSorted[2].data.pixels.byteLength).toBeGreaterThan(0);
-		expect(iconsSorted[2].data.isIcon() && iconsSorted[2].data.masks).toBeTruthy();
+		[[16, 16], [32, 32], [64, 64]].forEach(([width, height], i) => {
+			const icon = iconsSorted[i];
+			expect(icon.width).toEqual(width);
+			expect(icon.height).toEqual(height);
+			expect(icon.bitCount).toEqual(4);
+			expect(icon.data.isIcon()).toBeTruthy();
+			expect(icon.data.isIcon() && icon.data.pixels.byteLength).toBeGreaterThan(0);
+			expect(icon.data.isIcon() && icon.data.masks).toBeTruthy();
+			expect(icon.data.isIcon() && icon.data.width).toEqual(width);
+			expect(icon.data.isIcon() && icon.data.height).toEqual(height);
+		});
 		expect(getIconWidth(iconsSorted[3])).toEqual(256);
 		expect(getIconHeight(iconsSorted[3])).toEqual(256);
 		expect(iconsSorted[3].data.isRaw()).toBeTruthy();
 		expect(iconsSorted[3].data.isRaw() && iconsSorted[3].data.bin.byteLength).toBeGreaterThan(0);
+		expect(iconsSorted[3].data.isRaw() && iconsSorted[3].data.width).toEqual(256);
+		expect(iconsSorted[3].data.isRaw() && iconsSorted[3].data.height).toEqual(256);
 	});
 });


### PR DESCRIPTION
`IconItem` now contains icon width and height, that overrides original bitmap width and height. (These values should be same (except for containing mask bits), but in structure they are stored independently.)

This PR also fixes the height value by checking mask bits availability, when the value is not specified in `IconItem`.

Should fix #4.