### PR TITLE
Support ES module for Node.js (not full support)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .work/
 dist/
+src/_esm
 **/*.d.ts

--- a/jest.config.basic.js
+++ b/jest.config.basic.js
@@ -6,7 +6,9 @@ module.exports = {
 	testEnvironment: 'node',
 	testMatch: ['<rootDir>/src/test/basic/**/*.ts'],
 	moduleNameMapper: {
+		'^@/(.*)\\.js$': '<rootDir>/src/main/$1',
 		'^@/(.*)$': '<rootDir>/src/main/$1',
+		'(.+)\\.js': '$1',
 	},
 	globals: {
 		__TEST_PLATFORM__: 'any',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,7 +1021,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/node": {
@@ -1568,7 +1568,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -1595,7 +1595,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "convert-source-map": {
@@ -1789,7 +1789,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint": {
@@ -2191,7 +2191,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expect": {
@@ -2297,7 +2297,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastq": {
@@ -2665,7 +2665,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bigint": {
@@ -2714,7 +2714,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -3650,7 +3650,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json5": {
@@ -3805,7 +3805,7 @@
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-releases": {
@@ -3972,9 +3972,9 @@
       "dev": true
     },
     "pe-library": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.3.0.tgz",
-      "integrity": "sha512-mMVGKfeI6VOLqMOCiLaU4KNd4cgk8YcQVvJ07YIA6iujM4uKOgmDsmIp1qsKWEHt8cMoizVGFniQUrtN6pjtJA=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.0.tgz",
+      "integrity": "sha512-JAmVv2jGxmczplhHO7UoFGJ+pM/yMBpny3vNjwNFuaeQfzKlekQidZ8Ss8EJ0qee8wEQN4lY2IwtWx2oRfMsag=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -4121,7 +4121,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "resolve": {
@@ -4268,7 +4268,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "stack-utils": {
@@ -4343,7 +4343,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-final-newline": {
@@ -4407,7 +4407,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "tmpl": {
@@ -4419,7 +4419,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
   "description": "Node.js library editing Windows Resource data",
   "main": "./dist/index.js",
   "module": "./dist/_esm/index.js",
+  "exports": {
+    "node": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "import": "./dist/_esm/index.js",
+    "require": "./dist/index.js"
+  },
   "types": "./dist/index.d.ts",
   "author": "jet",
   "license": "MIT",
@@ -32,7 +40,7 @@
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc -p ./tsconfig.app.json",
-    "build:esm": "tsc -p ./tsconfig.app.esm.json",
+    "build:esm": "tsc -p ./tsconfig.app.esm.json && node ./tools/copyEsmFile.js",
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:eslint": "eslint -c .eslintrc.yml --ext .js,.jsx,.ts,.tsx .",
     "lint:eslint:fix": "eslint -c .eslintrc.yml --fix --ext .js,.jsx,.ts,.tsx .",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "version": "node ./tools/updateVersion.js ./src/main/version.ts && git add -A ./src/main/version.ts"
   },
   "dependencies": {
-    "pe-library": "^0.3.0"
+    "pe-library": "^0.4.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.0",

--- a/src/_esm/index.mjs
+++ b/src/_esm/index.mjs
@@ -1,0 +1,21 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+	NtExecutable,
+	NtExecutableResource,
+	version,
+	Data,
+	Format,
+	Resource,
+	generateExecutableWithSign,
+} = require('./index.js');
+export {
+	NtExecutable,
+	NtExecutableResource,
+	version,
+	Data,
+	Format,
+	Resource,
+	generateExecutableWithSign,
+};

--- a/src/main/data/IconFile.ts
+++ b/src/main/data/IconFile.ts
@@ -1,5 +1,5 @@
-import IconItem from './IconItem';
-import RawIconItem from './RawIconItem';
+import IconItem from './IconItem.js';
+import RawIconItem from './RawIconItem.js';
 
 import {
 	readUint8WithLastOffset,
@@ -7,7 +7,7 @@ import {
 	readUint32WithLastOffset,
 	copyBuffer,
 	createDataView,
-} from '../util/functions';
+} from '../util/functions.js';
 
 // struct ICON_GROUP {
 //   uint16_t reserved;

--- a/src/main/data/IconItem.ts
+++ b/src/main/data/IconItem.ts
@@ -1,4 +1,4 @@
-import BitmapInfo from './BitmapInfo';
+import BitmapInfo from './BitmapInfo.js';
 
 import {
 	allocatePartialBinary,
@@ -9,7 +9,7 @@ import {
 	readUint16WithLastOffset,
 	readUint32WithLastOffset,
 	roundUp,
-} from '../util/functions';
+} from '../util/functions.js';
 
 function calcMaskSize(width: number, height: number) {
 	// round up to 4 bytes (32 bit)

--- a/src/main/data/RawIconItem.ts
+++ b/src/main/data/RawIconItem.ts
@@ -1,4 +1,4 @@
-import { allocatePartialBinary } from '../util/functions';
+import { allocatePartialBinary } from '../util/functions.js';
 
 /**
  * Represents the raw-graphic icon item, such as PNG data.

--- a/src/main/data/index.ts
+++ b/src/main/data/index.ts
@@ -1,6 +1,6 @@
-import BitmapInfo from './BitmapInfo';
-import IconFile, { IconFileItem } from './IconFile';
-import IconItem from './IconItem';
-import RawIconItem from './RawIconItem';
+import BitmapInfo from './BitmapInfo.js';
+import IconFile, { IconFileItem } from './IconFile.js';
+import IconItem from './IconItem.js';
+import RawIconItem from './RawIconItem.js';
 
 export { BitmapInfo, IconFile, IconFileItem, IconItem, RawIconItem };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,15 +1,15 @@
 import { NtExecutable, NtExecutableResource, Format } from 'pe-library';
-import version from './version';
+import version from './version.js';
 
-import * as Data from './data';
-import * as Resource from './resource';
+import * as Data from './data/index.js';
+import * as Resource from './resource/index.js';
 
 import {
 	generateExecutableWithSign,
 	SignerObject,
 	DigestAlgorithmType,
 	EncryptionAlgorithmType,
-} from './sign';
+} from './sign/index.js';
 
 export {
 	NtExecutable,

--- a/src/main/resource/IconGroupEntry.ts
+++ b/src/main/resource/IconGroupEntry.ts
@@ -1,13 +1,13 @@
 import { Type } from 'pe-library';
 
-import IconItem from '../data/IconItem';
-import RawIconItem from '../data/RawIconItem';
+import IconItem from '../data/IconItem.js';
+import RawIconItem from '../data/RawIconItem.js';
 
 import {
 	readUint8WithLastOffset,
 	readUint16WithLastOffset,
 	readUint32WithLastOffset,
-} from '../util/functions';
+} from '../util/functions.js';
 
 // struct ICON_GROUP {
 //   uint16_t reserved;

--- a/src/main/resource/StringTable.ts
+++ b/src/main/resource/StringTable.ts
@@ -1,6 +1,6 @@
 import { NtExecutableResource, Type } from 'pe-library';
 
-import StringTableItem from './StringTableItem';
+import StringTableItem from './StringTableItem.js';
 
 /** Utility class to create / parse String Table resource */
 export default class StringTable {

--- a/src/main/resource/VersionInfo.ts
+++ b/src/main/resource/VersionInfo.ts
@@ -6,7 +6,7 @@ import {
 	copyBuffer,
 	readUint32WithLastOffset,
 	roundUp,
-} from '../util/functions';
+} from '../util/functions.js';
 
 /**
  * String values for the version information.

--- a/src/main/resource/index.ts
+++ b/src/main/resource/index.ts
@@ -1,20 +1,20 @@
 import { Type } from 'pe-library';
-import IconGroupEntry, { IconGroupItem } from './IconGroupEntry';
-import StringTable from './StringTable';
-import VersionFileFlags from './VersionFileFlags';
-import VersionFileOS from './VersionFileOS';
+import IconGroupEntry, { IconGroupItem } from './IconGroupEntry.js';
+import StringTable from './StringTable.js';
+import VersionFileFlags from './VersionFileFlags.js';
+import VersionFileOS from './VersionFileOS.js';
 import {
 	VersionFileDriverSubtype,
 	VersionFileFontSubtype,
-} from './VersionFileSubtypes';
-import VersionFileType from './VersionFileType';
+} from './VersionFileSubtypes.js';
+import VersionFileType from './VersionFileType.js';
 import VersionInfo, {
 	VersionInfoCreateParam,
 	VersionFixedInfo,
 	VersionStringTable,
 	VersionStringValues,
 	VersionTranslation,
-} from './VersionInfo';
+} from './VersionInfo.js';
 
 type ResourceEntry = Type.ResourceEntry;
 type ResourceEntryBaseType<

--- a/src/main/sign/certUtil.ts
+++ b/src/main/sign/certUtil.ts
@@ -1,5 +1,5 @@
-import DERObject, { RawDERObject } from './data/DERObject';
-import { OID_SIGNED_DATA } from './data/KnownOids';
+import DERObject, { RawDERObject } from './data/DERObject.js';
+import { OID_SIGNED_DATA } from './data/KnownOids.js';
 
 export function toUint8Array(bin: ArrayBuffer | ArrayBufferView): Uint8Array {
 	if ('buffer' in bin) {

--- a/src/main/sign/data/AlgorithmIdentifier.ts
+++ b/src/main/sign/data/AlgorithmIdentifier.ts
@@ -1,6 +1,6 @@
-import DERObject from './DERObject';
-import ObjectIdentifier from './ObjectIdentifier';
-import { makeDERSequence } from './derUtil';
+import DERObject from './DERObject.js';
+import ObjectIdentifier from './ObjectIdentifier.js';
+import { makeDERSequence } from './derUtil.js';
 
 export default class AlgorithmIdentifier implements DERObject {
 	constructor(public algorithm: ObjectIdentifier) {}

--- a/src/main/sign/data/Attribute.ts
+++ b/src/main/sign/data/Attribute.ts
@@ -1,6 +1,6 @@
-import DERObject from './DERObject';
-import ObjectIdentifier from './ObjectIdentifier';
-import { makeDERSequence, arrayToDERSet } from './derUtil';
+import DERObject from './DERObject.js';
+import ObjectIdentifier from './ObjectIdentifier.js';
+import { makeDERSequence, arrayToDERSet } from './derUtil.js';
 
 export default class Attribute implements DERObject {
 	constructor(

--- a/src/main/sign/data/CertificateDataRoot.ts
+++ b/src/main/sign/data/CertificateDataRoot.ts
@@ -1,4 +1,4 @@
-import ContentInfo from './ContentInfo';
-import SignedData from './SignedData';
+import ContentInfo from './ContentInfo.js';
+import SignedData from './SignedData.js';
 
 export default class CertificateDataRoot extends ContentInfo<SignedData> {}

--- a/src/main/sign/data/ContentInfo.ts
+++ b/src/main/sign/data/ContentInfo.ts
@@ -1,6 +1,6 @@
-import DERObject from './DERObject';
-import ObjectIdentifier from './ObjectIdentifier';
-import { makeDERSequence, makeDERTaggedData } from './derUtil';
+import DERObject from './DERObject.js';
+import ObjectIdentifier from './ObjectIdentifier.js';
+import { makeDERSequence, makeDERTaggedData } from './derUtil.js';
 
 // abstract
 export default class ContentInfo<TContent extends DERObject = DERObject>

--- a/src/main/sign/data/DigestInfo.ts
+++ b/src/main/sign/data/DigestInfo.ts
@@ -1,6 +1,6 @@
-import AlgorithmIdentifier from './AlgorithmIdentifier';
-import DERObject from './DERObject';
-import { makeDERSequence, makeDEROctetString } from './derUtil';
+import AlgorithmIdentifier from './AlgorithmIdentifier.js';
+import DERObject from './DERObject.js';
+import { makeDERSequence, makeDEROctetString } from './derUtil.js';
 
 export default class DigestInfo implements DERObject {
 	constructor(

--- a/src/main/sign/data/IssuerAndSerialNumber.ts
+++ b/src/main/sign/data/IssuerAndSerialNumber.ts
@@ -1,5 +1,5 @@
-import DERObject from './DERObject';
-import { makeDERSequence } from './derUtil';
+import DERObject from './DERObject.js';
+import { makeDERSequence } from './derUtil.js';
 
 export default class IssuerAndSerialNumber implements DERObject {
 	constructor(public issuer: DERObject, public serialNumber: DERObject) {}

--- a/src/main/sign/data/KnownOids.ts
+++ b/src/main/sign/data/KnownOids.ts
@@ -1,4 +1,4 @@
-import ObjectIdentifier from './ObjectIdentifier';
+import ObjectIdentifier from './ObjectIdentifier.js';
 
 // 1.3.14.3.2.26
 // prettier-ignore

--- a/src/main/sign/data/ObjectIdentifier.ts
+++ b/src/main/sign/data/ObjectIdentifier.ts
@@ -1,5 +1,5 @@
-import DERObject from './DERObject';
-import { makeDERLength } from './derUtil';
+import DERObject from './DERObject.js';
+import { makeDERLength } from './derUtil.js';
 
 export default class ObjectIdentifier implements DERObject {
 	public value: number[];

--- a/src/main/sign/data/SignedData.ts
+++ b/src/main/sign/data/SignedData.ts
@@ -1,7 +1,11 @@
-import DigestAlgorithmIdentifier from './AlgorithmIdentifier';
-import ContentInfo from './ContentInfo';
-import DERObject from './DERObject';
-import { arrayToDERSet, makeDERSequence, makeDERTaggedData } from './derUtil';
+import DigestAlgorithmIdentifier from './AlgorithmIdentifier.js';
+import ContentInfo from './ContentInfo.js';
+import DERObject from './DERObject.js';
+import {
+	arrayToDERSet,
+	makeDERSequence,
+	makeDERTaggedData,
+} from './derUtil.js';
 
 export default class SignedData implements DERObject {
 	constructor(

--- a/src/main/sign/data/SignerInfo.ts
+++ b/src/main/sign/data/SignerInfo.ts
@@ -1,8 +1,12 @@
-import DERObject from './DERObject';
-import IssuerAndSerialNumber from './IssuerAndSerialNumber';
-import { makeDERSequence, arrayToDERSet, makeDEROctetString } from './derUtil';
-import AlgorithmIdentifier from './AlgorithmIdentifier';
-import Attribute from './Attribute';
+import DERObject from './DERObject.js';
+import IssuerAndSerialNumber from './IssuerAndSerialNumber.js';
+import {
+	makeDERSequence,
+	arrayToDERSet,
+	makeDEROctetString,
+} from './derUtil.js';
+import AlgorithmIdentifier from './AlgorithmIdentifier.js';
+import Attribute from './Attribute.js';
 
 export default class SignerInfo implements DERObject {
 	constructor(

--- a/src/main/sign/data/SpcIndirectDataContent.ts
+++ b/src/main/sign/data/SpcIndirectDataContent.ts
@@ -1,8 +1,8 @@
-import ContentInfo from './ContentInfo';
-import DigestInfo from './DigestInfo';
-import ObjectIdentifier from './ObjectIdentifier';
-import DERObject from './DERObject';
-import { makeDERSequence } from './derUtil';
+import ContentInfo from './ContentInfo.js';
+import DigestInfo from './DigestInfo.js';
+import ObjectIdentifier from './ObjectIdentifier.js';
+import DERObject from './DERObject.js';
+import { makeDERSequence } from './derUtil.js';
 
 // prettier-ignore
 export const SPC_INDIRECT_DATA_OBJID = new ObjectIdentifier([1,3,6,1,4,1,311,2,1,4]);

--- a/src/main/sign/data/SpcLink.ts
+++ b/src/main/sign/data/SpcLink.ts
@@ -1,9 +1,9 @@
-import DERObject, { RawDERObject } from './DERObject';
+import DERObject, { RawDERObject } from './DERObject.js';
 import {
 	makeDERTaggedData,
 	makeDERIA5String,
 	makeDERBMPString,
-} from './derUtil';
+} from './derUtil.js';
 
 /**
  * Abstract data SpcLink. Must use either `SpcLinkUrl` or `SpcLinkFile` instead.

--- a/src/main/sign/data/SpcPeImageData.ts
+++ b/src/main/sign/data/SpcPeImageData.ts
@@ -1,8 +1,8 @@
-import DERObject from './DERObject';
-import ObjectIdentifier from './ObjectIdentifier';
-import { SpcAttributeTypeAndOptionalValue } from './SpcIndirectDataContent';
-import SpcLink from './SpcLink';
-import { makeDERSequence, makeDERTaggedData } from './derUtil';
+import DERObject from './DERObject.js';
+import ObjectIdentifier from './ObjectIdentifier.js';
+import { SpcAttributeTypeAndOptionalValue } from './SpcIndirectDataContent.js';
+import SpcLink from './SpcLink.js';
+import { makeDERSequence, makeDERTaggedData } from './derUtil.js';
 
 // prettier-ignore
 export const SPC_PE_IMAGE_DATA_OBJID = new ObjectIdentifier([1,3,6,1,4,1,311,2,1,15]);

--- a/src/main/sign/data/derUtil.ts
+++ b/src/main/sign/data/derUtil.ts
@@ -1,4 +1,4 @@
-import DERObject from './DERObject';
+import DERObject from './DERObject.js';
 
 export function makeDERLength(length: number): number[] {
 	if (length < 0x80) {

--- a/src/main/sign/index.ts
+++ b/src/main/sign/index.ts
@@ -19,49 +19,49 @@ import { NtExecutable, Format, calculateCheckSumForPE } from 'pe-library';
 import SignerObject, {
 	DigestAlgorithmType,
 	EncryptionAlgorithmType,
-} from './SignerObject';
+} from './SignerObject.js';
 
 import {
 	allocatePartialBinary,
 	cloneToArrayBuffer,
 	copyBuffer,
 	roundUp,
-} from '../util/functions';
+} from '../util/functions.js';
 
 import {
 	certBinToCertificatesDER,
 	pickIssuerAndSerialNumberDERFromCert,
 	toUint8Array,
-} from './certUtil';
-import AlgorithmIdentifier from './data/AlgorithmIdentifier';
-import CertificateDataRoot from './data/CertificateDataRoot';
-import { RawDERObject } from './data/DERObject';
-import DigestInfo from './data/DigestInfo';
-import IssuerAndSerialNumber from './data/IssuerAndSerialNumber';
-import * as KnownOids from './data/KnownOids';
-import SignedData from './data/SignedData';
-import SignerInfo from './data/SignerInfo';
+} from './certUtil.js';
+import AlgorithmIdentifier from './data/AlgorithmIdentifier.js';
+import CertificateDataRoot from './data/CertificateDataRoot.js';
+import { RawDERObject } from './data/DERObject.js';
+import DigestInfo from './data/DigestInfo.js';
+import IssuerAndSerialNumber from './data/IssuerAndSerialNumber.js';
+import * as KnownOids from './data/KnownOids.js';
+import SignedData from './data/SignedData.js';
+import SignerInfo from './data/SignerInfo.js';
 import SpcIndirectDataContent, {
 	SpcIndirectDataContentInfo,
 	SPC_INDIRECT_DATA_OBJID,
-} from './data/SpcIndirectDataContent';
+} from './data/SpcIndirectDataContent.js';
 import SpcPeImageData, {
 	SpcPeImageAttributeTypeAndOptionalValue,
 	SpcPeImageFlags,
-} from './data/SpcPeImageData';
-import { SpcLinkFile } from './data/SpcLink';
-import Attribute from './data/Attribute';
+} from './data/SpcPeImageData.js';
+import { SpcLinkFile } from './data/SpcLink.js';
+import Attribute from './data/Attribute.js';
 import {
 	arrayToDERSet,
 	makeDEROctetString,
 	makeDERSequence,
-} from './data/derUtil';
-import ContentInfo from './data/ContentInfo';
-import ObjectIdentifier from './data/ObjectIdentifier';
+} from './data/derUtil.js';
+import ContentInfo from './data/ContentInfo.js';
+import ObjectIdentifier from './data/ObjectIdentifier.js';
 import {
 	createTimestampRequest,
 	pickSignedDataFromTimestampResponse,
-} from './timestamp';
+} from './timestamp.js';
 
 type AnyBinary = ArrayBuffer | ArrayBufferView;
 

--- a/src/main/sign/timestamp.ts
+++ b/src/main/sign/timestamp.ts
@@ -1,8 +1,8 @@
-import { allocatePartialBinary } from '../util/functions';
-import { calculateDERLength, toUint8Array } from './certUtil';
-import { makeDEROctetString, makeDERSequence } from './data/derUtil';
-import AlgorithmIdentifier from './data/AlgorithmIdentifier';
-import { OID_SIGNED_DATA } from './data/KnownOids';
+import { allocatePartialBinary } from '../util/functions.js';
+import { calculateDERLength, toUint8Array } from './certUtil.js';
+import { makeDEROctetString, makeDERSequence } from './data/derUtil.js';
+import AlgorithmIdentifier from './data/AlgorithmIdentifier.js';
+import { OID_SIGNED_DATA } from './data/KnownOids.js';
 
 export function createTimestampRequest(
 	data: ArrayBuffer | ArrayBufferView,

--- a/src/test/basic/data/IconFile.ts
+++ b/src/test/basic/data/IconFile.ts
@@ -1,6 +1,6 @@
-import { loadIcon } from '../../util/fs';
+import { loadIcon } from '../../util/fs.js';
 
-import IconFile, { IconFileItem } from '@/data/IconFile';
+import IconFile, { IconFileItem } from '@/data/IconFile.js';
 
 function getIconWidth(icon: IconFileItem) {
 	return icon.width !== undefined && icon.width !== 0

--- a/src/test/basic/sign/data/ObjectIdentifier.ts
+++ b/src/test/basic/sign/data/ObjectIdentifier.ts
@@ -1,4 +1,4 @@
-import ObjectIdentifier from '@/sign/data/ObjectIdentifier';
+import ObjectIdentifier from '@/sign/data/ObjectIdentifier.js';
 
 describe('ObjectIdentifier', () => {
 	it('should make DER correctly (with only <128 values)', () => {

--- a/src/test/basic/sign/data/derUtil.ts
+++ b/src/test/basic/sign/data/derUtil.ts
@@ -6,8 +6,8 @@ import {
 	makeDEROctetString,
 	makeDERSequence,
 	makeDERTaggedData,
-} from '@/sign/data/derUtil';
-import { RawDERObject } from '@/sign/data/DERObject';
+} from '@/sign/data/derUtil.js';
+import { RawDERObject } from '@/sign/data/DERObject.js';
 
 describe('arrayToDERSet', () => {
 	it('should make valid DER (with no items)', () => {

--- a/src/test/basic/sign/timestamp.ts
+++ b/src/test/basic/sign/timestamp.ts
@@ -1,9 +1,9 @@
 import {
 	createTimestampRequest,
 	pickSignedDataFromTimestampResponse,
-} from '@/sign/timestamp';
-import AlgorithmIdentifier from '@/sign/data/AlgorithmIdentifier';
-import { OID_SHA1_NO_SIGN } from '@/sign/data/KnownOids';
+} from '@/sign/timestamp.js';
+import AlgorithmIdentifier from '@/sign/data/AlgorithmIdentifier.js';
+import { OID_SHA1_NO_SIGN } from '@/sign/data/KnownOids.js';
 
 describe('createTimestampRequest', () => {
 	// prettier-ignore

--- a/src/test/basic/util/functions.ts
+++ b/src/test/basic/util/functions.ts
@@ -1,4 +1,4 @@
-import { copyBuffer, createDataView } from '@/util/functions';
+import { copyBuffer, createDataView } from '@/util/functions.js';
 
 function generateArrayBuffer(pattern: number[]) {
 	const bin = new ArrayBuffer(pattern.length);

--- a/src/test/win/IconGroupEntry.ts
+++ b/src/test/win/IconGroupEntry.ts
@@ -4,10 +4,10 @@ import {
 	loadExecutableWithResourceCheck,
 	loadIcon,
 	testExec,
-} from '../util/fs';
+} from '../util/fs.js';
 
-import IconFile from '@/data/IconFile';
-import IconGroupEntry from '@/resource/IconGroupEntry';
+import IconFile from '@/data/IconFile.js';
+import IconGroupEntry from '@/resource/IconGroupEntry.js';
 
 const platform = __TEST_PLATFORM__;
 

--- a/src/test/win/SignExecutable.ts
+++ b/src/test/win/SignExecutable.ts
@@ -8,7 +8,7 @@ import {
 	loadPrivatePem,
 	runExec,
 	writeBinary,
-} from '../util/fs';
+} from '../util/fs.js';
 import {
 	DigestAlgorithmType,
 	EncryptionAlgorithmType,

--- a/src/test/win/StringTable.ts
+++ b/src/test/win/StringTable.ts
@@ -1,8 +1,8 @@
 import { Format, NtExecutableResource } from 'pe-library';
 
-import { loadExecutableWithResourceCheck, testExec } from '../util/fs';
+import { loadExecutableWithResourceCheck, testExec } from '../util/fs.js';
 
-import StringTable from '@/resource/StringTable';
+import StringTable from '@/resource/StringTable.js';
 
 const platform = __TEST_PLATFORM__;
 

--- a/src/test/win/VersionInfo.ts
+++ b/src/test/win/VersionInfo.ts
@@ -1,11 +1,11 @@
 import { Format, NtExecutableResource } from 'pe-library';
 
-import { loadExecutableWithResourceCheck, testExec } from '../util/fs';
+import { loadExecutableWithResourceCheck, testExec } from '../util/fs.js';
 
-import VersionFileFlags from '@/resource/VersionFileFlags';
-import VersionFileOS from '@/resource/VersionFileOS';
-import VersionFileType from '@/resource/VersionFileType';
-import VersionInfo, { VersionFixedInfo } from '@/resource/VersionInfo';
+import VersionFileFlags from '@/resource/VersionFileFlags.js';
+import VersionFileOS from '@/resource/VersionFileOS.js';
+import VersionFileType from '@/resource/VersionFileType.js';
+import VersionInfo, { VersionFixedInfo } from '@/resource/VersionInfo.js';
 
 const platform = __TEST_PLATFORM__;
 

--- a/tools/copyEsmFile.js
+++ b/tools/copyEsmFile.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+try {
+	fs.mkdirSync(path.join(ROOT_DIR, 'dist'));
+} catch {}
+
+fs.writeFileSync(
+	path.join(ROOT_DIR, 'dist/index.mjs'),
+	fs.readFileSync(path.join(ROOT_DIR, 'src/_esm/index.mjs'), 'utf8'),
+	'utf8'
+);


### PR DESCRIPTION
This is almost same for jet2jet/pe-library-js#3.
Related: #34 

This PR enables to load pe-library as a native ES module. To keep compatibility, importing pe-library in Node.js environment will load CommonJS source code, so this PR is not full support for ES module.

(In the next major version release, I'll change API for CommonJS. → #35 )